### PR TITLE
Corresponding negative values

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -165,6 +165,7 @@ fn float_to_int<T,U,V>(orginal: T,precision: u8) -> (U,V)
 fn float_to_int_f32(orginal: f32, precision: u8) -> (i32, u32) {
 	#[allow(unused_imports)]
 	use micromath::F32Ext;
+	let negative_flag = orginal.is_sign_negative();
 	let prec = match precision {
 		1 => 10.0,
 		2 => 100.0,
@@ -174,13 +175,14 @@ fn float_to_int_f32(orginal: f32, precision: u8) -> (i32, u32) {
 		_ => 0.0,
 	};
 	let base = orginal.trunc() as i32;
-	let decimal = (orginal.fract() * prec) as u32;
+	let decimal = if negative_flag { (-orginal.fract() * prec) as u32 } else { (orginal.fract() * prec) as u32 };
 	(base, decimal)
 }
 
 ///Split the float into the integer and the fraction with the correct precision
 #[cfg(not(feature = "maths"))]
 fn float_to_int_f32(orginal: f32, precision: u8) -> (i32, u32) {
+	let negative_flag = orginal.is_sign_negative();
 	let prec = match precision {
 		1 => 10.0,
 		2 => 100.0,
@@ -190,12 +192,17 @@ fn float_to_int_f32(orginal: f32, precision: u8) -> (i32, u32) {
 		_ => 0.0,
 	};
 	let base = orginal as i32;
-	let decimal = ((orginal - (base as f32)) * prec) as u32;
+	let decimal = if negative_flag {
+		((-orginal + (base as f32)) * prec) as u32
+	} else {
+		((orginal - (base as f32)) * prec) as u32
+	};
 	(base, decimal)
 }
 
 ///Split the float into the integer and the fraction with the correct precision
 fn float_to_int_f64(orginal: f64, precision: u8) -> (i32, u32) {
+	let negative_flag = orginal.is_sign_negative();
 	let prec = match precision {
 		1 => 10.0,
 		2 => 100.0,
@@ -205,6 +212,10 @@ fn float_to_int_f64(orginal: f64, precision: u8) -> (i32, u32) {
 		_ => 0.0,
 	};
 	let base = orginal as i32;
-	let decimal = ((orginal - (base as f64)) * prec) as u32;
+	let decimal = if negative_flag {
+		((-orginal + (base as f64)) * prec) as u32
+	} else {
+		((orginal - (base as f64)) * prec) as u32
+	};
 	(base, decimal)
 }

--- a/tests/format-tests.rs
+++ b/tests/format-tests.rs
@@ -123,3 +123,111 @@ fn format_heapless() {
 	ufmt::uwrite!(&mut s, "{}", number_write).unwrap();
 	assert_eq!(s, "3.14");
 }
+
+#[test]
+fn format_negative_f32() {
+	use ufmt_float::uFmt_f32;
+	let pi = -3.14159234;
+
+	let mut s = String::new();
+	let pi_write = uFmt_f32::Zero(pi);
+	ufmt::uwrite!(&mut s, "{}", pi_write).unwrap();
+	assert_eq!(s, "-3");
+
+	let mut s = String::new();
+	let pi_write = uFmt_f32::One(pi);
+	ufmt::uwrite!(&mut s, "{}", pi_write).unwrap();
+	assert_eq!(s, "-3.1");
+
+	let mut s = String::new();
+	let pi_write = uFmt_f32::Two(pi);
+	ufmt::uwrite!(&mut s, "{}", pi_write).unwrap();
+	assert_eq!(s, "-3.14");
+
+	let mut s = String::new();
+	let pi_write = uFmt_f32::Three(pi);
+	ufmt::uwrite!(&mut s, "{}", pi_write).unwrap();
+	assert_eq!(s, "-3.141");
+
+	let mut s = String::new();
+	let pi_write = uFmt_f32::Four(pi);
+	ufmt::uwrite!(&mut s, "{}", pi_write).unwrap();
+	assert_eq!(s, "-3.1415");
+
+	let mut s = String::new();
+	let pi_write = uFmt_f32::Five(pi);
+	ufmt::uwrite!(&mut s, "{}", pi_write).unwrap();
+	assert_eq!(s, "-3.14159");
+
+	let number = -134539.0312;
+	let mut s = String::new();
+	let number_write = uFmt_f32::Two(number);
+	ufmt::uwrite!(&mut s, "{}", number_write).unwrap();
+	assert_eq!(s, "-134539.03");
+
+	let number = -1439.0034345;
+	let mut s = String::new();
+	let number_write = uFmt_f32::Three(number);
+	ufmt::uwrite!(&mut s, "{}", number_write).unwrap();
+	assert_eq!(s, "-1439.003");
+
+	let number = -13538.0006256;
+	let mut s = String::new();
+	let number_write = uFmt_f32::Four(number);
+	ufmt::uwrite!(&mut s, "{}", number_write).unwrap();
+	assert_ne!(s, "-13539.0008");
+}
+
+#[test]
+fn format_negative_f64() {
+	use ufmt_float::uFmt_f64;
+	let pi = -3.14159234;
+
+	let mut s = String::new();
+	let pi_write = uFmt_f64::Zero(pi);
+	ufmt::uwrite!(&mut s, "{}", pi_write).unwrap();
+	assert_eq!(s, "-3");
+
+	let mut s = String::new();
+	let pi_write = uFmt_f64::One(pi);
+	ufmt::uwrite!(&mut s, "{}", pi_write).unwrap();
+	assert_eq!(s, "-3.1");
+
+	let mut s = String::new();
+	let pi_write = uFmt_f64::Two(pi);
+	ufmt::uwrite!(&mut s, "{}", pi_write).unwrap();
+	assert_eq!(s, "-3.14");
+
+	let mut s = String::new();
+	let pi_write = uFmt_f64::Three(pi);
+	ufmt::uwrite!(&mut s, "{}", pi_write).unwrap();
+	assert_eq!(s, "-3.141");
+
+	let mut s = String::new();
+	let pi_write = uFmt_f64::Four(pi);
+	ufmt::uwrite!(&mut s, "{}", pi_write).unwrap();
+	assert_eq!(s, "-3.1415");
+
+	let mut s = String::new();
+	let pi_write = uFmt_f64::Five(pi);
+	ufmt::uwrite!(&mut s, "{}", pi_write).unwrap();
+	assert_eq!(s, "-3.14159");
+
+	let number = -134539.037897;
+	let mut s = String::new();
+	let number_write = uFmt_f64::Two(number);
+	ufmt::uwrite!(&mut s, "{}", number_write).unwrap();
+	assert_eq!(s, "-134539.03");
+
+	let number = -134539.0033897;
+	let mut s = String::new();
+	let number_write = uFmt_f64::Three(number);
+	ufmt::uwrite!(&mut s, "{}", number_write).unwrap();
+	assert_eq!(s, "-134539.003");
+
+	let number = -134539.0003789;
+	let mut s = String::new();
+	let number_write = uFmt_f64::Four(number);
+	ufmt::uwrite!(&mut s, "{}", number_write).unwrap();
+	assert_eq!(s, "-134539.0003");
+}


### PR DESCRIPTION
When attempting to display a negative value, the decimal portion was all zeros, but this has been changed so that even decimal values are displayed correctly.