### PR TITLE
Fix display of numbers in the `(-1, 0)` interval

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,14 +51,17 @@ impl uDisplay for uFmt_f32 {
 		W: uWrite + ?Sized,
 	{
 		use uFmt_f32::*;
-		let (number, decimals) = match self {
-			Zero(x) => float_to_int_f32(*x, 0),
-			One(x) => float_to_int_f32(*x, 1),
-			Two(x) => float_to_int_f32(*x, 2),
-			Three(x) => float_to_int_f32(*x, 3),
-			Four(x) => float_to_int_f32(*x, 4),
-			Five(x) => float_to_int_f32(*x, 5),
+
+		let (x, precision) = match self {
+			Zero(x) => (*x, 0),
+			One(x) => (*x, 1),
+			Two(x) => (*x, 2),
+			Three(x) => (*x, 3),
+			Four(x) => (*x, 4),
+			Five(x) => (*x, 5),
 		};
+		let (number, decimals) = float_to_int_f32(x, precision);
+		if precision != 0 && number == 0 && x.is_sign_negative() { uwrite!(f, "-")?; }
 		uwrite!(f, "{}", number)?;
 
 		match self {
@@ -107,14 +110,17 @@ impl uDisplay for uFmt_f64 {
 		W: uWrite + ?Sized,
 	{
 		use uFmt_f64::*;
-		let (number, decimals) = match self {
-			Zero(x) => float_to_int_f64(*x, 0),
-			One(x) => float_to_int_f64(*x, 1),
-			Two(x) => float_to_int_f64(*x, 2),
-			Three(x) => float_to_int_f64(*x, 3),
-			Four(x) => float_to_int_f64(*x, 4),
-			Five(x) => float_to_int_f64(*x, 5),
+
+		let (x, precision) = match self {
+			Zero(x) => (*x, 0),
+			One(x) => (*x, 1),
+			Two(x) => (*x, 2),
+			Three(x) => (*x, 3),
+			Four(x) => (*x, 4),
+			Five(x) => (*x, 5),
 		};
+		let (number, decimals) = float_to_int_f64(x, precision);
+		if precision != 0 && x.is_sign_negative() && x > -1. { uwrite!(f, "-")?; }
 		uwrite!(f, "{}", number)?;
 
 		match self {

--- a/tests/format-tests.rs
+++ b/tests/format-tests.rs
@@ -52,6 +52,18 @@ fn format_f32() {
 	let number_write = uFmt_f32::Four(number);
 	ufmt::uwrite!(&mut s, "{}", number_write).unwrap();
 	assert_ne!(s, "13539.0008");
+
+	let small_pi = 0.31415924;
+
+	let mut s = String::new();
+	let pi_write = uFmt_f32::Zero(small_pi);
+	ufmt::uwrite!(&mut s, "{}", pi_write).unwrap();
+	assert_eq!(s, "0");
+
+	let mut s = String::new();
+	let pi_write = uFmt_f32::One(small_pi);
+	ufmt::uwrite!(&mut s, "{}", pi_write).unwrap();
+	assert_eq!(s, "0.3");
 }
 
 #[test]
@@ -106,6 +118,18 @@ fn format_f64() {
 	let number_write = uFmt_f64::Four(number);
 	ufmt::uwrite!(&mut s, "{}", number_write).unwrap();
 	assert_eq!(s, "134539.0003");
+
+	let small_pi = 0.31415924;
+
+	let mut s = String::new();
+	let pi_write = uFmt_f64::Zero(small_pi);
+	ufmt::uwrite!(&mut s, "{}", pi_write).unwrap();
+	assert_eq!(s, "0");
+
+	let mut s = String::new();
+	let pi_write = uFmt_f64::One(small_pi);
+	ufmt::uwrite!(&mut s, "{}", pi_write).unwrap();
+	assert_eq!(s, "0.3");
 }
 
 #[test]
@@ -176,6 +200,18 @@ fn format_negative_f32() {
 	let number_write = uFmt_f32::Four(number);
 	ufmt::uwrite!(&mut s, "{}", number_write).unwrap();
 	assert_ne!(s, "-13539.0008");
+
+	let small_pi = -0.31415924;
+
+	let mut s = String::new();
+	let pi_write = uFmt_f32::Zero(small_pi);
+	ufmt::uwrite!(&mut s, "{}", pi_write).unwrap();
+	assert_eq!(s, "0");
+
+	let mut s = String::new();
+	let pi_write = uFmt_f32::One(small_pi);
+	ufmt::uwrite!(&mut s, "{}", pi_write).unwrap();
+	assert_eq!(s, "-0.3");
 }
 
 #[test]
@@ -230,4 +266,16 @@ fn format_negative_f64() {
 	let number_write = uFmt_f64::Four(number);
 	ufmt::uwrite!(&mut s, "{}", number_write).unwrap();
 	assert_eq!(s, "-134539.0003");
+
+	let small_pi = -0.31415924;
+
+	let mut s = String::new();
+	let pi_write = uFmt_f64::Zero(small_pi);
+	ufmt::uwrite!(&mut s, "{}", pi_write).unwrap();
+	assert_eq!(s, "0");
+
+	let mut s = String::new();
+	let pi_write = uFmt_f64::One(small_pi);
+	ufmt::uwrite!(&mut s, "{}", pi_write).unwrap();
+	assert_eq!(s, "-0.3");
 }


### PR DESCRIPTION
Currently, numbers in the `(-1, 0)` interval (e.g. -0.314) get wrongly formatted. In particular, the `-` sign gets omitted.

In this PR I fixed this issue by manually adding the `-` sign in front of the number when needed. I also added more tests to cover this scenario.

Let me know if there's anything else I can do!